### PR TITLE
ADD variable to configure service endpoints (#60)

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,12 @@ module "network" {
   subnet_prefixes     = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
   subnet_names        = ["subnet1", "subnet2", "subnet3"]
 
+  subnet_service_endpoints = {
+    "subnet1" : ["Microsoft.Sql"], 
+    "subnet2" : ["Microsoft.Sql"],
+    "subnet3" : ["Microsoft.Sql"]
+  }
+
   tags = {
     environment = "dev"
     costcenter  = "it"
@@ -55,6 +61,12 @@ module "network" {
 
   subnet_enforce_private_link_endpoint_network_policies = {
     "subnet1" : true
+  }
+
+  subnet_service_endpoints = {
+    "subnet1" : ["Microsoft.Sql"], 
+    "subnet2" : ["Microsoft.Sql"],
+    "subnet3" : ["Microsoft.Sql"]
   }
 
   tags = {

--- a/main.tf
+++ b/main.tf
@@ -19,4 +19,5 @@ resource "azurerm_subnet" "subnet" {
   address_prefixes                               = [var.subnet_prefixes[count.index]]
   virtual_network_name                           = azurerm_virtual_network.vnet.name
   enforce_private_link_endpoint_network_policies = lookup(var.subnet_enforce_private_link_endpoint_network_policies, var.subnet_names[count.index], false)
+  service_endpoints                              = lookup(var.subnet_service_endpoints, var.subnet_names[count.index], [])
 }

--- a/test/fixture/main.tf
+++ b/test/fixture/main.tf
@@ -22,6 +22,10 @@ module "network" {
     "subnet1" : true
   }
 
+  subnet_service_endpoints = {
+    "subnet1" : ["Microsoft.Sql"]
+  }
+
   tags = {
     environment = "dev"
     costcenter  = "it"

--- a/variables.tf
+++ b/variables.tf
@@ -54,3 +54,9 @@ variable "subnet_enforce_private_link_endpoint_network_policies" {
   type        = map(bool)
   default     = {}
 }
+
+variable "subnet_service_endpoints" {
+  description = "A map with key (string) `subnet name`, value (list(string)) to indicate enabled service endpoints on the subnet. Default value is []."
+  type        = map(list(string))
+  default     = {}
+}


### PR DESCRIPTION
* feat: add variable subnet_service_endpoints to set service_endpoints

* test: udpate fixture

* docs: add subnet_service_endpoints in example in README

<!---
Please add this into the test of test/fixture, format the changes by "terraform fmt", and test it by run the following:
```sh
$ docker build --build-arg BUILD_ARM_SUBSCRIPTION_ID=$ARM_SUBSCRIPTION_ID --build-arg BUILD_ARM_CLIENT_ID=$ARM_CLIENT_ID --build-arg BUILD_ARM_CLIENT_SECRET=$ARM_CLIENT_SECRET --build-arg BUILD_ARM_TENANT_ID=$ARM_TENANT_ID -t azure-network .
$ docker run --rm azure-network /bin/bash -c "bundle install && rake full"
```
Please add this into the example usage of README.md and format the changes by "terrafmt fmt README.md". Please intall "terrafmt" by [install terrafmt](https://github.com/katbyte/terrafmt#install).
--->

Fixes #000 

Changes proposed in the pull request:


